### PR TITLE
Restore regular unsplatted arguments for open3 subprocess

### DIFF
--- a/bin/check-minio-update.rb
+++ b/bin/check-minio-update.rb
@@ -73,7 +73,7 @@ class CheckMinioUpdate < Sensu::Plugin::Check::CLI
   end
 
   def get_local_version
-    stdout, stderr, status = Open3.capture3([{'PATH' => ENV['PATH']}, 'minio --version', :unsetenv_others => true])
+    stdout, stderr, status = Open3.capture3({ 'PATH' => ENV['PATH'] }, 'minio --version', :unsetenv_others => true)
 
     raise IOError, "Unable to gather local minio version: #{stderr}" unless status.success?
 

--- a/spec/check-minio-update_spec.rb
+++ b/spec/check-minio-update_spec.rb
@@ -80,7 +80,7 @@ describe CheckMinioUpdate do
     end
   end
 
-  context 'with release url not found' do ||
+  context 'with release url not found' do
     let(:response) { { body: '404 Not Found', status: 404 } }
 
     it 'should be unknown' do

--- a/spec/check-minio-update_spec.rb
+++ b/spec/check-minio-update_spec.rb
@@ -9,8 +9,7 @@ describe CheckMinioUpdate do
   before do
     stub_checksum_request
     allow(check).to(receive(:output))
-    allow(Open3).to(receive(:capture3).with(array_including('minio --version'))
-                                      .and_return([stdout, stderr, double(:success? => success)]))
+    allow(Open3).to(receive(:capture3).and_return([stdout, stderr, double(:success? => success)]))
   end
 
   let(:checksum_request) do


### PR DESCRIPTION
[(3) Minio Update Check kaputt](https://trello.com/c/vXPQGlqF/3521-3-minio-update-check-kaputt-sensucheckminioupdatedefekt)